### PR TITLE
WIP builder redux

### DIFF
--- a/src/test/java/com/github/ermay12/regex/PasswordTest.java
+++ b/src/test/java/com/github/ermay12/regex/PasswordTest.java
@@ -2,12 +2,44 @@ package com.github.ermay12.regex;
 
 import org.junit.Test;
 
+
 import static com.github.ermay12.regex.RegexBuilder.StaticHelpers.*;
 import static org.junit.Assert.assertEquals;
 
 public class PasswordTest {
     @Test
     public void testPassword() {
+
+        //Without importing everything
+        Regex regex =
+            new Regex(
+                Regex.LINESTART,
+                Regex.lookahead(Charset.WILDCARD.anyAmount(), Charset.range('a', 'z')),
+                Regex.lookahead(Charset.WILDCARD.anyAmount(), Charset.range('A', 'Z')),
+                Regex.lookahead(Charset.WILDCARD.anyAmount(), Charset.DIGIT),
+                Regex.lookahead(Charset.WILDCARD.anyAmount(), Charset.without(Charset.WORD_CHAR)),
+                Charset.WILDCARD.repeatAtLeast(8),
+                Regex.LINEEND
+            );
+
+        // importing everything
+        import static com.github.ermay12.regex.Regex.*;
+        import static com.github.ermay12.regex.Charset.*;
+        import com.github.ermay12.regex.Regex;
+        import com.github.ermay12.regex.Charset;
+
+
+        Regex regex =
+            new Regex(
+                LINESTART,
+                lookahead(WILDCARD.anyAmount(), range('a', 'z')),
+                lookahead(WILDCARD.anyAmount(), range('A', 'Z')),
+                lookahead(WILDCARD.anyAmount(), DIGIT),
+                lookahead(WILDCARD.anyAmount(), Charset.without(WORD_CHAR)),
+                WILDCARD.repeatAtLeast(8),
+                LINEEND
+            );
+
         Regex regex =
                 startLine()
                 .lookahead(anyAmount(wildcard()).single(range('a', 'z')))

--- a/src/test/java/com/github/ermay12/regex/YoutubeTest.java
+++ b/src/test/java/com/github/ermay12/regex/YoutubeTest.java
@@ -8,7 +8,56 @@ import static org.junit.Assert.assertEquals;
 public class YoutubeTest {
     @Test
     public void youtubeTest() {
-        Regex regex =
+
+      //without static imports
+      RegexGroup group = new Regex(
+          Charset.without('#', '&', '?').anyAmount()
+      );
+
+      Regex regex =
+          new Regex(
+              Regex.LINESTART,
+              Charset.WILDCARD.anyAmount(),
+              Regex.oneOf(
+                  Regex.string("youtu.be/"),
+                  Regex.string("v/"),
+                  Regex.string("/u/w/"),
+                  Regex.string("embed/"),
+                  Regex.string("watch?")
+              ),
+              Regex.optional("?"),
+              Regex.optional("v"),
+              Regex.optional("="),
+              group,
+              Regex.string("asdasd").anyAmount()
+          );
+
+
+
+      //with static imports
+      RegexGroup group = new Regex(
+          Charset.without('#', '&', '?').anyAmount()
+      );
+
+      Regex regex =
+          new Regex(
+              LINESTART,
+              WILDCARD.anyAmount(),
+              oneOf(
+                  string("youtu.be/"),
+                  string("v/"),
+                  string("/u/w/"),
+                  string("embed/"),
+                  string("watch?")
+              ),
+              optional("?"),
+              optional("v"),
+              optional("="),
+              group,
+              string("asdasd").anyAmount()
+          );
+
+      Regex regex =
                 startLine()
                 .anyAmount(wildcard())
                 .or(


### PR DESCRIPTION
rethought how some of the api should look

Issues this addresses:
-or is an infix operator and should not be used.  this is most misleading in the phone number example
-statically importing everything might be problematic for some users so the api should still be readable to users that don't do that
-certain methods in the current version really represent objects and should be treated as constants (WILDCARD, LINESTART, ...)
-by default, a regex expression should represent that it must occur once without stating that explicitly
-a clearer structure to the regex language